### PR TITLE
feat: add Gateway API support

### DIFF
--- a/charts/jxboot-helmfile-resources/templates/700-bucketrepo-httpr.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-bucketrepo-httpr.yaml
@@ -1,0 +1,29 @@
+{{- if and (eq "bucketrepo" .Values.jxRequirements.repository) (not .Values.istio.enabled) (eq "httproute" .Values.bucketrepo.ingressType) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- $annotations := include "httpRouteAnnotations" (dict "Values" .Values "component" "bucketrepo") }}
+{{- if $annotations }}
+  annotations:
+  {{- $annotations | nindent 4 }}
+{{- end }}
+  name: bucketrepo
+spec:
+{{- $parentRefs := include "httpRouteParentRefs" (dict "Values" .Values "component" "bucketrepo") }}
+{{- if trim $parentRefs }}
+  parentRefs:
+  {{- $parentRefs | nindent 2 }}
+{{- end }}
+{{- if or .Values.bucketrepo.httpRoute.customHost .Values.jxRequirements.ingress.domain }}
+  hostnames:
+  - {{ include "httpRouteHostname" (dict "Values" .Values "component" "bucketrepo") }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: bucketrepo
+      port: 80
+{{- end }}

--- a/charts/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq "bucketrepo" .Values.jxRequirements.repository) (not .Values.istio.enabled) }}
+{{- if and (eq "bucketrepo" .Values.jxRequirements.repository) (not .Values.istio.enabled) (ne "httproute" .Values.bucketrepo.ingressType) }}
 apiVersion: {{ .Values.ingress.apiVersion | default "networking.k8s.io/v1" }}
 kind: Ingress
 metadata:

--- a/charts/jxboot-helmfile-resources/templates/700-chartmuseum-httpr.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-chartmuseum-httpr.yaml
@@ -1,0 +1,29 @@
+{{- if and (not (or (eq "bucketrepo" .Values.jxRequirements.repository) (not .Values.jxRequirements.repository) (eq "none" .Values.jxRequirements.repository))) (not .Values.istio.enabled) (eq "httproute" .Values.chartmuseum.ingressType) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- $annotations := include "httpRouteAnnotations" (dict "Values" .Values "component" "chartmuseum") }}
+{{- if $annotations }}
+  annotations:
+  {{- $annotations | nindent 4 }}
+{{- end }}
+  name: chartmuseum
+spec:
+{{- $parentRefs := include "httpRouteParentRefs" (dict "Values" .Values "component" "chartmuseum") }}
+{{- if trim $parentRefs }}
+  parentRefs:
+  {{- $parentRefs | nindent 2 }}
+{{- end }}
+{{- if or .Values.chartmuseum.httpRoute.customHost .Values.jxRequirements.ingress.domain }}
+  hostnames:
+  - {{ include "httpRouteHostname" (dict "Values" .Values "component" "chartmuseum") }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: jenkins-x-chartmuseum
+      port: 8080
+{{- end }}

--- a/charts/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (or (eq "bucketrepo" .Values.jxRequirements.repository) (not .Values.jxRequirements.repository) (eq "none" .Values.jxRequirements.repository))) (not .Values.istio.enabled) }}
+{{- if and (not (or (eq "bucketrepo" .Values.jxRequirements.repository) (not .Values.jxRequirements.repository) (eq "none" .Values.jxRequirements.repository))) (not .Values.istio.enabled) (ne "httproute" .Values.chartmuseum.ingressType) }}
 apiVersion: {{ .Values.ingress.apiVersion | default "networking.k8s.io/v1" }}
 kind: Ingress
 metadata:

--- a/charts/jxboot-helmfile-resources/templates/700-docker-httpr.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-docker-httpr.yaml
@@ -1,0 +1,29 @@
+{{- if and (index .Values "docker-registry" "enabled") (not .Values.istio.enabled) (eq "httproute" (index .Values "docker-registry" "ingressType")) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- $annotations := include "httpRouteAnnotations" (dict "Values" .Values "component" "docker-registry") }}
+{{- if $annotations }}
+  annotations:
+  {{- $annotations | nindent 4 }}
+{{- end }}
+  name: docker-registry
+spec:
+{{- $parentRefs := include "httpRouteParentRefs" (dict "Values" .Values "component" "docker-registry") }}
+{{- if trim $parentRefs }}
+  parentRefs:
+  {{- $parentRefs | nindent 2 }}
+{{- end }}
+{{- if or (index .Values "docker-registry" "httpRoute" "customHost") .Values.jxRequirements.ingress.domain }}
+  hostnames:
+  - {{ include "httpRouteHostname" (dict "Values" .Values "component" "docker-registry") }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: jenkins-x-docker-registry
+      port: 5000
+{{- end }}

--- a/charts/jxboot-helmfile-resources/templates/700-docker-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-docker-ing.yaml
@@ -1,4 +1,4 @@
-{{- if and (index .Values "docker-registry" "enabled") (not .Values.istio.enabled) }}
+{{- if and (index .Values "docker-registry" "enabled") (not .Values.istio.enabled) (ne "httproute" (index .Values "docker-registry" "ingressType")) }}
 apiVersion: {{ .Values.ingress.apiVersion | default "networking.k8s.io/v1" }}
 kind: Ingress
 metadata:

--- a/charts/jxboot-helmfile-resources/templates/700-hook-httpr.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-hook-httpr.yaml
@@ -1,0 +1,29 @@
+{{- if and (or (eq "lighthouse" .Values.jxRequirements.webhook) (eq "prow" .Values.jxRequirements.webhook)) (not .Values.istio.enabled) (eq "httproute" .Values.hook.ingressType) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- $annotations := include "httpRouteAnnotations" (dict "Values" .Values "component" "hook") }}
+{{- if $annotations }}
+  annotations:
+  {{- $annotations | nindent 4 }}
+{{- end }}
+  name: hook
+spec:
+{{- $parentRefs := include "httpRouteParentRefs" (dict "Values" .Values "component" "hook") }}
+{{- if trim $parentRefs }}
+  parentRefs:
+  {{- $parentRefs | nindent 2 }}
+{{- end }}
+{{- if or .Values.hook.httpRoute.customHost .Values.jxRequirements.ingress.domain }}
+  hostnames:
+  - {{ include "httpRouteHostname" (dict "Values" .Values "component" "hook") }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /hook
+    backendRefs:
+    - name: hook
+      port: 80
+{{- end }}

--- a/charts/jxboot-helmfile-resources/templates/700-hook-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-hook-ing.yaml
@@ -1,4 +1,4 @@
-{{- if and (or (eq "lighthouse" .Values.jxRequirements.webhook) (eq "prow" .Values.jxRequirements.webhook)) (not .Values.istio.enabled) }}
+{{- if and (or (eq "lighthouse" .Values.jxRequirements.webhook) (eq "prow" .Values.jxRequirements.webhook)) (not .Values.istio.enabled) (ne "httproute" .Values.hook.ingressType) }}
 apiVersion: {{ .Values.ingress.apiVersion | default "networking.k8s.io/v1" }}
 kind: Ingress
 metadata:

--- a/charts/jxboot-helmfile-resources/templates/700-nexus-httpr.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-nexus-httpr.yaml
@@ -1,0 +1,29 @@
+{{- if and (eq "nexus" .Values.jxRequirements.repository) (not .Values.istio.enabled) (eq "httproute" .Values.nexus.ingressType) }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+{{- $annotations := include "httpRouteAnnotations" (dict "Values" .Values "component" "nexus") }}
+{{- if $annotations }}
+  annotations:
+  {{- $annotations | nindent 4 }}
+{{- end }}
+  name: nexus
+spec:
+{{- $parentRefs := include "httpRouteParentRefs" (dict "Values" .Values "component" "nexus") }}
+{{- if trim $parentRefs }}
+  parentRefs:
+  {{- $parentRefs | nindent 2 }}
+{{- end }}
+{{- if or .Values.nexus.httpRoute.customHost .Values.jxRequirements.ingress.domain }}
+  hostnames:
+  - {{ include "httpRouteHostname" (dict "Values" .Values "component" "nexus") }}
+{{- end }}
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    backendRefs:
+    - name: nexus
+      port: 80
+{{- end }}

--- a/charts/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq "nexus" .Values.jxRequirements.repository) (not .Values.istio.enabled) }}
+{{- if and (eq "nexus" .Values.jxRequirements.repository) (not .Values.istio.enabled) (ne "httproute" .Values.nexus.ingressType) }}
 apiVersion: {{ .Values.ingress.apiVersion | default "networking.k8s.io/v1" }}
 kind: Ingress
 metadata:

--- a/charts/jxboot-helmfile-resources/templates/_helpers.tpl
+++ b/charts/jxboot-helmfile-resources/templates/_helpers.tpl
@@ -35,3 +35,64 @@
 {{ toYaml $annotations | indent 4 }}
   {{- end }}
 {{- end }}
+
+{{- /*
+httpRouteParentRefs renders the parentRefs list for an HTTPRoute.
+
+When jxRequirements.ingress.kind is "httproute" the default envoy-gateway "http"
+listener is attached, plus the "https" listener when
+jxRequirements.ingress.tls.enabled is true. Any per-component
+httpRoute.customParentRefs are then appended.
+
+When ingress.kind is anything other than "httproute" no defaults are injected
+and the parentRefs are exactly the user-supplied httpRoute.customParentRefs, so
+users running their own gateway can fully control attachment.
+
+Call with (dict "Values" .Values "component" "<name>").
+*/ -}}
+{{- define "httpRouteParentRefs" -}}
+{{- $spec := index .Values .component -}}
+{{- $refs := list -}}
+{{- if eq "httproute" .Values.jxRequirements.ingress.kind -}}
+{{- $refs = append $refs (dict "name" "envoy-gateway" "namespace" "envoy-gateway-system" "sectionName" "http") -}}
+{{- if .Values.jxRequirements.ingress.tls.enabled -}}
+{{- $refs = append $refs (dict "name" "envoy-gateway" "namespace" "envoy-gateway-system" "sectionName" "https") -}}
+{{- end -}}
+{{- end -}}
+{{- range $spec.httpRoute.customParentRefs -}}
+{{- $refs = append $refs . -}}
+{{- end -}}
+{{- if $refs -}}
+{{ toYaml $refs }}
+{{- end -}}
+{{- end }}
+
+{{- /*
+httpRouteHostname returns the hostname for a component's HTTPRoute: the
+per-component httpRoute.customHost if set, otherwise the composed
+<prefix><namespaceSubDomain><domain>. The prefix falls back to the component's
+ingress.prefix when httpRoute.prefix is not set. Call with
+(dict "Values" .Values "component" "<name>").
+*/ -}}
+{{- define "httpRouteHostname" -}}
+{{- $spec := index .Values .component -}}
+{{- if $spec.httpRoute.customHost -}}
+{{ $spec.httpRoute.customHost }}
+{{- else -}}
+{{ $spec.httpRoute.prefix | default $spec.ingress.prefix }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- end -}}
+{{- end }}
+
+{{- /*
+httpRouteAnnotations returns the per-component httpRoute.annotations as raw
+(unindented) YAML, or an empty string when there are none. Call with
+(dict "Values" .Values "component" "<name>"); the caller is responsible for
+indenting (e.g. `nindent 4`) and for only emitting the `annotations:` key when
+the result is non-empty.
+*/ -}}
+{{- define "httpRouteAnnotations" -}}
+{{- $spec := index .Values .component -}}
+{{- if $spec.httpRoute.annotations -}}
+{{ toYaml $spec.httpRoute.annotations }}
+{{- end -}}
+{{- end }}

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -44,6 +44,7 @@ pipeline:
       email: jenkins-x@googlecloud.com
 
 bucketrepo:
+  ingressType: ingress # options: ingress, httproute
   ingress:
     annotations: {}
     customHost: "" # setting this will override the value from .Values.ingress.customHost.bucketrepo
@@ -51,8 +52,14 @@ bucketrepo:
     prefix: bucketrepo
     tls:
       secretName: ""
+  httpRoute:
+    annotations: {}
+    customHost: ""
+    prefix: bucketrepo
+    customParentRefs: []
 
 chartmuseum:
+  ingressType: ingress # options: ingress, httproute
   ingress:
     annotations: {}
     customHost: "" # setting this will override the value from .Values.ingress.customHost.chartmuseum
@@ -60,9 +67,15 @@ chartmuseum:
     prefix: chartmuseum
     tls:
       secretName: ""
+  httpRoute:
+    annotations: {}
+    customHost: ""
+    prefix: chartmuseum
+    customParentRefs: []
 
 docker-registry:
   enabled: false
+  ingressType: ingress # options: ingress, httproute
   ingress:
     annotations: {}
     customHost: "" # setting this will override the value from .Values.ingress.customHost.dockerRegistry
@@ -70,8 +83,14 @@ docker-registry:
     prefix: docker-registry
     tls:
       secretName: ""
+  httpRoute:
+    annotations: {}
+    customHost: ""
+    prefix: docker-registry
+    customParentRefs: []
 
 hook:
+  ingressType: ingress # options: ingress, httproute
   ingress:
     annotations: {}
     customHost: "" # setting this will override the value from .Values.ingress.customHost.hook
@@ -79,8 +98,14 @@ hook:
     prefix: hook
     tls:
       secretName: ""
+  httpRoute:
+    annotations: {}
+    customHost: ""
+    prefix: hook
+    customParentRefs: []
 
 nexus:
+  ingressType: ingress # options: ingress, httproute
   ingress:
     annotations: {}
     customHost: "" # setting this will override the value from .Values.ingress.customHost.nexus
@@ -88,6 +113,10 @@ nexus:
     prefix: nexus # setting this will override the value from .Values.ingress.prefix.nexus
     tls:
       secretName: ""
+  httpRoute:
+    annotations: {}
+    customHost: ""
+    customParentRefs: []
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress


### PR DESCRIPTION
### Changes
* Create Gateway API `HTTPRoute` templates for `bucketrepo`, `chartmuseum`, `docker-registry`, `hook` and `nexus` services under `700-*-httpr.yaml`, mirroring existing `Ingress`es
* Add `ingressType` key and `httpRoute` block under each service in `values.yaml` for routing configuration
* Guard each existing `700-*-ing.yaml` to skip when `ingressType: httproute`
* Add `HTTPRoute` helpers to `_helpers.tpl`

### Context

Adds Gateway API compatibility for the internet-facing services deployed by this chart, so clusters running a Gateway API implementation (e.g. Envoy Gateway) can expose these services via `HTTPRoute`s

Setting `ingressType: (ingress | httproute)` switches the networking type for each. This defaults to `ingress`, so existing chart deployments are unaffected.

The `httpRouteParentRefs` helper interfaces with JX Requirements:
  * If `jxRequirements.ingress.kind: httproute`, then the chart assumes `envoy-gateway` has been deployed to the `envoy-gateway-system` cluster namespace. The `http` listener is attached as a `parentRef` for each deployed `HTTPRoute`
  * If `jxRequirements.ingress.tls.enabled: true`, an additional `https` listener is attached as a second `parentRef`

The `customParentRefs` field allows users to set a parent Gateway independent of JX configuration